### PR TITLE
Add excerpt rendering for blog posts using markdown-it

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "astro": "^5.1.1",
     "astro-auto-import": "^0.4.4",
     "astro-icon": "^1.1.4",
+    "markdown-it": "^14.1.0",
     "tailwindcss": "^3.4.16",
     "tailwindcss-animate": "^1.0.7",
     "vidstack": "^1.12.12"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       astro-icon:
         specifier: ^1.1.4
         version: 1.1.4
+      markdown-it:
+        specifier: ^14.1.0
+        version: 14.1.0
       tailwindcss:
         specifier: ^3.4.16
         version: 3.4.16
@@ -1542,6 +1545,9 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
   listhen@1.9.0:
     resolution: {integrity: sha512-I8oW2+QL5KJo8zXNWX046M134WchxsXC7SawLPvRQpogCbkyQIaFxPE89A2HiwR7vAK2Dm2ERBAmyjTYGYEpBg==}
     hasBin: true
@@ -1585,6 +1591,10 @@ packages:
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
+
+  markdown-it@14.1.0:
+    resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
+    hasBin: true
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -1645,6 +1655,9 @@ packages:
 
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   media-captions@1.0.4:
     resolution: {integrity: sha512-cyDNmuZvvO4H27rcBq2Eudxo9IZRDCOX/I7VEyqbxsEiD2Ei7UYUhG/Sc5fvMZjmathgz3fEK7iAKqvpY+Ux1w==}
@@ -2055,6 +2068,10 @@ packages:
   pump@3.0.2:
     resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
 
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -2314,6 +2331,9 @@ packages:
     resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   ufo@1.5.4:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
@@ -4188,6 +4208,10 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
   listhen@1.9.0:
     dependencies:
       '@parcel/watcher': 2.5.0
@@ -4250,6 +4274,15 @@ snapshots:
       source-map-js: 1.2.1
 
   markdown-extensions@2.0.0: {}
+
+  markdown-it@14.1.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
 
@@ -4425,6 +4458,8 @@ snapshots:
   mdn-data@2.0.28: {}
 
   mdn-data@2.0.30: {}
+
+  mdurl@2.0.0: {}
 
   media-captions@1.0.4: {}
 
@@ -4965,6 +5000,8 @@ snapshots:
       end-of-stream: 1.4.4
       once: 1.4.0
 
+  punycode.js@2.3.1: {}
+
   queue-microtask@1.2.3: {}
 
   radix3@1.1.2: {}
@@ -5362,6 +5399,8 @@ snapshots:
   type-fest@4.30.1: {}
 
   typescript@5.7.2: {}
+
+  uc.micro@2.1.0: {}
 
   ufo@1.5.4: {}
 

--- a/src/pages/blog/[page].astro
+++ b/src/pages/blog/[page].astro
@@ -1,7 +1,19 @@
 ---
 import Layout from '../../layouts/Layout.astro';
+import markdownit from 'markdown-it'
 import { Image } from 'astro:assets';
 import { getCollection } from 'astro:content';
+
+
+function getExcerpt(content) {
+  const md = markdownit()
+  const moreIndex = content.indexOf('{/* <!-- more --> */}');
+  if (moreIndex === -1) {
+    return content;
+  }
+  const excerpt = content.slice(0, moreIndex);
+  return md.render(excerpt);
+}
 
 export async function getStaticPaths( {paginate} ) {  
   const posts = await getCollection('posts');
@@ -13,14 +25,14 @@ export async function getStaticPaths( {paginate} ) {
 }
 
 const { page } = Astro.props;
-console.log(page.data);
 ---
 <Layout title="Blog">
-		{page.data.map((post) => 
+		{
+      page.data.map((post) => 
         <article class="bg-white p-6 flex">
           <div class="flex-1">
             <h2 class="text-2xl font-bold mb-4"><a href={`${post.data.permalink}`}>{post.data.title}</a></h2>
-            <p class="mb-4">Excerpt...</p>
+            <p class="mb-4" set:html={getExcerpt(post.body)}></p>
             <a href={`${post.data.permalink}`} class="text-blue-500 hover:underline">Continue reading</a>
           </div>
           <div class="ml-6">
@@ -31,7 +43,8 @@ console.log(page.data);
                    height="150" />
           </div>
         </article>
-		)}
+		  )
+    }
 <div class="flex justify-between items-center p-6">
   <div class="space-x-2">
     {page.url.first ? <a href={page.url.first} class="text-blue-500 hover:underline">First</a> : null}


### PR DESCRIPTION
This pull request includes updates to dependencies and improvements to the blog page rendering in the `astro` project. 

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R18): Added `markdown-it` version `^14.1.0`.

Blog page improvements:

* `src/pages/blog/[page].astro`: Imported `markdown-it` and added a `getExcerpt` function to render excerpts from blog posts using `markdown-it`. Updated the blog page template to use this function. ([src/pages/blog/[page].astroR3-R17](diffhunk://#diff-3c83c2fa11b7eaa00fe336e122ae9b83e849ffc47203936c6b7acbf1b8921389R3-R17), [src/pages/blog/[page].astroL16-R35](diffhunk://#diff-3c83c2fa11b7eaa00fe336e122ae9b83e849ffc47203936c6b7acbf1b8921389L16-R35), [src/pages/blog/[page].astroL34-R47](diffhunk://#diff-3c83c2fa11b7eaa00fe336e122ae9b83e849ffc47203936c6b7acbf1b8921389L34-R47))