### PR TITLE
Update to Astro 5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@iconify-json/fa6-brands": "^1.2.5",
     "@iconify-json/fa6-solid": "^1.2.3",
     "@tailwindcss/vite": "^4.0.4",
-    "astro": "^5.2.5",
+    "astro": "^5.3.0",
     "astro-auto-import": "^0.4.4",
     "astro-icon": "^1.1.5",
     "markdown-it": "^14.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@astrojs/mdx':
         specifier: ^4.0.8
-        version: 4.0.8(astro@5.2.5(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(rollup@4.34.4)(typescript@5.7.2)(yaml@2.6.1))
+        version: 4.0.8(astro@5.3.0(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(rollup@4.34.4)(typescript@5.7.2)(yaml@2.6.1))
       '@iconify-json/fa6-brands':
         specifier: ^1.2.5
         version: 1.2.5
@@ -21,11 +21,11 @@ importers:
         specifier: ^4.0.4
         version: 4.0.4(vite@6.1.0(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(yaml@2.6.1))
       astro:
-        specifier: ^5.2.5
-        version: 5.2.5(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(rollup@4.34.4)(typescript@5.7.2)(yaml@2.6.1)
+        specifier: ^5.3.0
+        version: 5.3.0(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(rollup@4.34.4)(typescript@5.7.2)(yaml@2.6.1)
       astro-auto-import:
         specifier: ^0.4.4
-        version: 0.4.4(astro@5.2.5(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(rollup@4.34.4)(typescript@5.7.2)(yaml@2.6.1))
+        version: 0.4.4(astro@5.3.0(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(rollup@4.34.4)(typescript@5.7.2)(yaml@2.6.1))
       astro-icon:
         specifier: ^1.1.5
         version: 1.1.5
@@ -718,8 +718,8 @@ packages:
   astro-icon@1.1.5:
     resolution: {integrity: sha512-CJYS5nWOw9jz4RpGWmzNQY7D0y2ZZacH7atL2K9DeJXJVaz7/5WrxeyIxO8KASk1jCM96Q4LjRx/F3R+InjJrw==}
 
-  astro@5.2.5:
-    resolution: {integrity: sha512-AYXyYkc+c5xbKTm48FyQA91y81nXyNPAaoyafR0LUugE4lAwuvIUcXDBfMzmbuP1lGRvsE33G2oypv6gbGaPFg==}
+  astro@5.3.0:
+    resolution: {integrity: sha512-e88l/Yk/6enR/ZDddLbqtM+oblBFk5mneNSmNesyVYGL/6Dj4UA67GPAZOk79VxT5dbLlclZSyyw/wlxN1aj3A==}
     engines: {node: ^18.17.1 || ^20.3.0 || >=22.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
@@ -2240,12 +2240,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.0.8(astro@5.2.5(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(rollup@4.34.4)(typescript@5.7.2)(yaml@2.6.1))':
+  '@astrojs/mdx@4.0.8(astro@5.3.0(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(rollup@4.34.4)(typescript@5.7.2)(yaml@2.6.1))':
     dependencies:
       '@astrojs/markdown-remark': 6.1.0
       '@mdx-js/mdx': 3.1.0(acorn@8.14.0)
       acorn: 8.14.0
-      astro: 5.2.5(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(rollup@4.34.4)(typescript@5.7.2)(yaml@2.6.1)
+      astro: 5.3.0(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(rollup@4.34.4)(typescript@5.7.2)(yaml@2.6.1)
       es-module-lexer: 1.6.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.4
@@ -2802,11 +2802,11 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-auto-import@0.4.4(astro@5.2.5(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(rollup@4.34.4)(typescript@5.7.2)(yaml@2.6.1)):
+  astro-auto-import@0.4.4(astro@5.3.0(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(rollup@4.34.4)(typescript@5.7.2)(yaml@2.6.1)):
     dependencies:
       '@types/node': 18.19.68
       acorn: 8.14.0
-      astro: 5.2.5(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(rollup@4.34.4)(typescript@5.7.2)(yaml@2.6.1)
+      astro: 5.3.0(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(rollup@4.34.4)(typescript@5.7.2)(yaml@2.6.1)
 
   astro-icon@1.1.5:
     dependencies:
@@ -2817,7 +2817,7 @@ snapshots:
       - debug
       - supports-color
 
-  astro@5.2.5(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(rollup@4.34.4)(typescript@5.7.2)(yaml@2.6.1):
+  astro@5.3.0(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(rollup@4.34.4)(typescript@5.7.2)(yaml@2.6.1):
     dependencies:
       '@astrojs/compiler': 2.10.3
       '@astrojs/internal-helpers': 0.5.1


### PR DESCRIPTION
This pull request includes updates to the `astro` package version across multiple files to ensure consistency and compatibility with the latest version.

Version updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L16-R16): Updated the `astro` package version from `^5.2.5` to `^5.3.0`.

Consistency updates in `pnpm-lock.yaml`:

* Updated the `astro` package version from `5.2.5` to `5.3.0` in the `importers:` section. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL13-R13) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL24-R28)
* Updated the `astro` package resolution from `5.2.5` to `5.3.0` in the `packages:` section.
* Updated the `astro` package version from `5.2.5` to `5.3.0` in the `snapshots:` section. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2243-R2248) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2805-R2809) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2820-R2820)