### PR TITLE
Refactor tag display in MarkdownPostLayout and enhance TagList compon…

### DIFF
--- a/src/components/TagList.astro
+++ b/src/components/TagList.astro
@@ -9,7 +9,7 @@ const { tags } = Astro.props;
 {tags && tags.length > 0 && (
   <div class="flex gap-1 flex-wrap">
     {tags.map(tag => (
-      <span class="px-1.5 py-0.5 bg-gray-100 dark:bg-gray-800 rounded-full">
+      <span class="px-1.5 py-0.5 bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-300 rounded-full text-xs">
         {tag}
       </span>
     ))}

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -1,4 +1,5 @@
 ---
+import TagList from '../components/TagList.astro';
 import Layout from './Layout.astro';
 import { Image } from 'astro:assets';
 const { frontmatter } = Astro.props;
@@ -16,17 +17,16 @@ const { frontmatter } = Astro.props;
       <p class="text-2xl sm:text-3xl md:text-5xl font-extrabold drop-shadow-[0_4px_3px_rgb(0,0,0,0.5)] dark:drop-shadow-[0_4px_3px_rgb(255,255,255,0.5)]">{frontmatter.title}</p>
       <p class="py-2 text-sm sm:text-base">{new Date(frontmatter.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}</p>
     </div>
+    <div class="absolute bottom-5 left-5">
+      <TagList tags={frontmatter.tags} />
+    </div>
     <p class="absolute text-sm sm:text-xs text-white bottom-5 right-5">{frontmatter.coverCaption !== undefined && frontmatter.coverCaption}</p>
   </div>
   <div class="py-4">
     <slot  />
   </div>
-  <div class="tags">
-      {frontmatter.tags.map((tag: string) => (
-          <p class="tag"><a href={`/tags/${tag}`}>{tag}</a></p>
-      ))}
-  </div>
 </Layout>
+
 <style>
     a {
       color: #00539F;


### PR DESCRIPTION
This pull request includes several changes to improve the display and management of tags in the `TagList` and `MarkdownPostLayout` components. The most important changes include updating the tag styling, importing the `TagList` component into the `MarkdownPostLayout`, and refactoring the tag display logic.

Changes to tag styling and display:

* [`src/components/TagList.astro`](diffhunk://#diff-01ae1062001571e001bee325ac6cd5a982dc93f5deaa6cc6e9bf66ef849687bfL12-R12): Updated the tag styling to include text color and size adjustments.

Refactoring and component updates:

* [`src/layouts/MarkdownPostLayout.astro`](diffhunk://#diff-bb0a91360a5fa7f1097b41c0bace94a5c4a1a0cdb7fec8d4dd1211c46695c911R2): Imported the `TagList` component and refactored the tag display logic to use this component instead of inline mapping. [[1]](diffhunk://#diff-bb0a91360a5fa7f1097b41c0bace94a5c4a1a0cdb7fec8d4dd1211c46695c911R2) [[2]](diffhunk://#diff-bb0a91360a5fa7f1097b41c0bace94a5c4a1a0cdb7fec8d4dd1211c46695c911R20-R29)