### PR TITLE
Add pagination component and integrate it into the blog page

### DIFF
--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -1,0 +1,49 @@
+---
+import { Icon } from 'astro-icon/components';
+import type { Page } from 'astro';
+
+interface Props {
+  page: Page<any>;
+  pageSize?: number;
+  displayCount?: number;
+}
+
+const { page, pageSize = 4, displayCount = 5 } = Astro.props;
+
+const totalPages = Math.ceil(page.total / pageSize);
+const currentPage = page.currentPage;
+
+// Calculate the range of pages to display
+const halfDisplay = Math.floor(displayCount / 2);
+let startPage = Math.max(currentPage - halfDisplay, 1);
+let endPage = Math.min(startPage + displayCount - 1, totalPages);
+
+// Adjust start if we're near the end
+if (endPage - startPage + 1 < displayCount) {
+  startPage = Math.max(endPage - displayCount + 1, 1);
+}
+---
+<div class="flex justify-between items-center p-6">
+  <div class="space-x-2 flex items-center">
+    {page.url.first ? <a href={page.url.first} class="text-blue-500 dark:text-blue-400 hover:underline"><Icon name="fa6-solid:angles-left" /></a> : null}
+    {page.url.prev ? <a href={page.url.prev} class="text-blue-500 dark:text-blue-400 hover:underline"><Icon name="fa6-solid:angle-left" /></a> : null}
+    {
+      Array.from({ length: endPage - startPage + 1 }, (_, i) => {
+        const pageNum = startPage + i;
+        return (
+          <a 
+            href={`/blog/${pageNum}`} 
+            class={`px-2 py-1 ${currentPage === pageNum ? 'bg-blue-500 text-white' : 'text-blue-500 dark:text-blue-400 hover:underline'}`}
+          >
+            {pageNum}
+          </a>
+        );
+      })
+    }
+    {page.url.next ? <a href={page.url.next} class="text-blue-500 dark:text-blue-400 hover:underline"><Icon name="fa6-solid:angle-right" /></a> : null}
+    {page.url.last ? <a href={page.url.last} class="text-blue-500 dark:text-blue-400 hover:underline"><Icon name="fa6-solid:angles-right" /></a> : null}
+  </div>
+  <div class="text-gray-600 dark:text-gray-400">
+    Page {currentPage} of {totalPages}
+  </div>
+</div>

--- a/src/pages/blog/[page].astro
+++ b/src/pages/blog/[page].astro
@@ -3,10 +3,12 @@ import Layout from '../../layouts/Layout.astro';
 import markdownit from 'markdown-it'
 import { Image } from 'astro:assets';
 import { getCollection } from 'astro:content';
-import { Icon } from 'astro-icon/components';
 import TagList from '../../components/TagList.astro';
+import Pagination from '../../components/Pagination.astro';
 import type { Page } from 'astro';
 import type { CollectionEntry } from 'astro:content';
+
+export const PAGE_SIZE = 4;
 
 function getExcerpt(content: string): string {
   const md = markdownit();
@@ -24,7 +26,7 @@ export async function getStaticPaths({ paginate }: { paginate: any }) {
   .sort(
     (a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime()
   );
-  return paginate(sortedPosts, { pageSize: 4 });
+  return paginate(sortedPosts, { pageSize: PAGE_SIZE });
 }
 
 const { page } = Astro.props;
@@ -33,7 +35,7 @@ type Props = {
 };
 ---
 <Layout title="Blog">
-		{
+    {
       page.data.map((post) => 
         <article class="bg-white dark:bg-gray-900 p-4 flex flex-col md:flex-row">
           <div class="flex-1">
@@ -59,22 +61,7 @@ type Props = {
             </a>
           </div>
         </article>
-		  )
+      )
     }
-  <div class="flex justify-between items-center p-6">
-    <div class="space-x-2 flex items-center">
-      {page.url.first ? <a href={page.url.first} class="text-blue-500 dark:text-blue-400 hover:underline"><Icon name="fa6-solid:angles-left" /></a> : null}
-      {page.url.prev ? <a href={page.url.prev} class="text-blue-500 dark:text-blue-400 hover:underline"><Icon name="fa6-solid:angle-left" /></a> : null}
-      {
-        Array.from({ length: Math.ceil(page.total / 4) }, (_, i) => (
-          <a href={`/blog/${i + 1}`} class={`px-2 py-1 ${page.currentPage === i + 1 ? 'bg-blue-500 text-white' : 'text-blue-500 dark:text-blue-400 hover:underline'}`}>{i + 1}</a>
-        ))
-      }
-      {page.url.next ? <a href={page.url.next} class="text-blue-500 dark:text-blue-400 hover:underline"><Icon name="fa6-solid:angle-right" /></a> : null}
-      {page.url.last ? <a href={page.url.last} class="text-blue-500 dark:text-blue-400 hover:underline"><Icon name="fa6-solid:angles-right" /></a> : null}
-    </div>
-    <div class="text-gray-600 dark:text-gray-400">
-      Page {page.currentPage} of {Math.ceil(page.total / 4)}
-    </div>
-  </div>
+    <Pagination page={page} pageSize={PAGE_SIZE} />
 </Layout>


### PR DESCRIPTION
This pull request introduces a new `Pagination` component to improve the pagination functionality of the blog pages. The changes primarily focus on extracting the pagination logic into a reusable component and updating the blog page to use this new component.

### Introduction of Pagination Component:

* [`src/components/Pagination.astro`](diffhunk://#diff-f09d0bb15fd289d6b7abf3e1f6d172001d9ff78d02f3ca95a2132379a9aab80eR1-R49): Added a new `Pagination` component to handle the pagination logic and UI. This includes calculating the range of pages to display and rendering appropriate navigation links.

### Updates to Blog Page:

* `src/pages/blog/[page].astro`: 
  * Imported the new `Pagination` component and removed the `Icon` import which is now handled by the `Pagination` component. ([src/pages/blog/[page].astroL6-R12](diffhunk://#diff-3c83c2fa11b7eaa00fe336e122ae9b83e849ffc47203936c6b7acbf1b8921389L6-R12))
  * Updated the `getStaticPaths` function to use the `PAGE_SIZE` constant for pagination. ([src/pages/blog/[page].astroL27-R29](diffhunk://#diff-3c83c2fa11b7eaa00fe336e122ae9b83e849ffc47203936c6b7acbf1b8921389L27-R29))
  * Replaced the inline pagination logic with the new `Pagination` component. ([src/pages/blog/[page].astroL64-R66](diffhunk://#diff-3c83c2fa11b7eaa00fe336e122ae9b83e849ffc47203936c6b7acbf1b8921389L64-R66))