### PR TITLE
Add paginated archive pages for years and months

### DIFF
--- a/src/pages/archives/[year]/[month]/index.astro
+++ b/src/pages/archives/[year]/[month]/index.astro
@@ -26,40 +26,42 @@ export async function getStaticPaths() {
       return date.getFullYear() === year && date.getMonth() === month - 1;
     });
 
+    const posts = monthPosts.slice(0, 4);
+    const totalPosts = monthPosts.length;
+    const page = {
+      data: posts,
+      start: 0,
+      end: 4,
+      total: totalPosts,
+      currentPage: 1,
+      size: 4,
+      lastPage: Math.ceil(totalPosts / 4),
+      url: {
+        current: `/archives/${year}/${String(month).padStart(2, '0')}`,
+        next: totalPosts > 4 ? `/archives/${year}/${String(month).padStart(2, '0')}/page/2` : undefined,
+        prev: undefined,
+        first: undefined, // Remove first page link on first page
+        last: totalPosts > 4 ? `/archives/${year}/${String(month).padStart(2, '0')}/page/${Math.ceil(totalPosts / 4)}` : undefined
+      }
+    };
+
     return {
       params: { 
         year: String(year), 
         month: String(month).padStart(2, '0')
       },
       props: { 
-        posts: monthPosts.slice(0, 4), 
+        page,
         year,
-        month,
-        totalPosts: monthPosts.length 
+        month
       }
     };
   });
 }
 
-const { posts, year, month, totalPosts } = Astro.props;
+const { page, year, month } = Astro.props;
 const monthName = new Date(year, month - 1).toLocaleString('en-US', { month: 'long' });
 const paddedMonth = String(month).padStart(2, '0');
-const page = {
-  data: posts,
-  start: 0,
-  end: 4,
-  total: totalPosts,
-  currentPage: 1,
-  size: 4,
-  lastPage: Math.ceil(totalPosts / 4),
-  url: {
-    current: `/archives/${year}/${paddedMonth}`,
-    next: totalPosts > 4 ? `/archives/${year}/${paddedMonth}/page/2` : undefined,
-    prev: undefined,
-    first: `/archives/${year}/${paddedMonth}`,
-    last: `/archives/${year}/${paddedMonth}/page/${Math.ceil(totalPosts / 4)}`
-  }
-};
 ---
 
 <Layout title={`Archives for ${monthName} ${year}`}>
@@ -67,7 +69,7 @@ const page = {
       Archives for {monthName} {year}
     </h1>
 
-    {posts.map((post: Post) => <BlogPostPreview post={post} />)}
+    {page.data.map((post: Post) => <BlogPostPreview post={post} />)}
 
     <Pagination 
       page={page}

--- a/src/pages/archives/[year]/[month]/index.astro
+++ b/src/pages/archives/[year]/[month]/index.astro
@@ -1,0 +1,76 @@
+---
+import Layout from '../../../../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+import BlogPostPreview from '../../../../components/BlogPostPreview.astro';
+import Pagination from '../../../../components/Pagination.astro';
+import type { CollectionEntry } from 'astro:content';
+
+type Post = CollectionEntry<'posts'>;
+
+export async function getStaticPaths() {
+  const allPosts = await getCollection("posts");
+  const sortedPosts = allPosts.sort((a, b) => 
+    new Date(b.data.date).getTime() - new Date(a.data.date).getTime()
+  );
+
+  // Get unique year/month combinations
+  const yearMonths = [...new Set(sortedPosts.map(post => {
+    const date = new Date(post.data.date);
+    return `${date.getFullYear()}-${date.getMonth() + 1}`;
+  }))];
+
+  return yearMonths.map(yearMonth => {
+    const [year, month] = yearMonth.split('-').map(Number);
+    const monthPosts = sortedPosts.filter(post => {
+      const date = new Date(post.data.date);
+      return date.getFullYear() === year && date.getMonth() === month - 1;
+    });
+
+    return {
+      params: { 
+        year: String(year), 
+        month: String(month).padStart(2, '0')
+      },
+      props: { 
+        posts: monthPosts.slice(0, 4), 
+        year,
+        month,
+        totalPosts: monthPosts.length 
+      }
+    };
+  });
+}
+
+const { posts, year, month, totalPosts } = Astro.props;
+const monthName = new Date(year, month - 1).toLocaleString('en-US', { month: 'long' });
+const paddedMonth = String(month).padStart(2, '0');
+const page = {
+  data: posts,
+  start: 0,
+  end: 4,
+  total: totalPosts,
+  currentPage: 1,
+  size: 4,
+  lastPage: Math.ceil(totalPosts / 4),
+  url: {
+    current: `/archives/${year}/${paddedMonth}`,
+    next: totalPosts > 4 ? `/archives/${year}/${paddedMonth}/page/2` : undefined,
+    prev: undefined,
+    first: `/archives/${year}/${paddedMonth}`,
+    last: `/archives/${year}/${paddedMonth}/page/${Math.ceil(totalPosts / 4)}`
+  }
+};
+---
+
+<Layout title={`Archives for ${monthName} ${year}`}>
+    <h1 class="text-2xl pl-4 pt-8 font-bold mb-8 text-gray-800 dark:text-gray-200">
+      Archives for {monthName} {year}
+    </h1>
+
+    {posts.map((post: Post) => <BlogPostPreview post={post} />)}
+
+    <Pagination 
+      page={page}
+      urlPattern={(pageNum) => `/archives/${year}/${paddedMonth}${pageNum === 1 ? '' : `/page/${pageNum}`}`}
+    />
+</Layout>

--- a/src/pages/archives/[year]/[month]/page/[page].astro
+++ b/src/pages/archives/[year]/[month]/page/[page].astro
@@ -1,0 +1,85 @@
+---
+import Layout from '../../../../../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+import BlogPostPreview from '../../../../../components/BlogPostPreview.astro';
+import Pagination from '../../../../../components/Pagination.astro';
+import type { CollectionEntry } from 'astro:content';
+
+type Post = CollectionEntry<'posts'>;
+
+export async function getStaticPaths() {
+  const allPosts = await getCollection("posts");
+  const sortedPosts = allPosts.sort((a, b) => 
+    new Date(b.data.date).getTime() - new Date(a.data.date).getTime()
+  );
+
+  // Get unique year/month combinations
+  const yearMonths = [...new Set(sortedPosts.map(post => {
+    const date = new Date(post.data.date);
+    return `${date.getFullYear()}-${date.getMonth() + 1}`;
+  }))];
+
+  return yearMonths.flatMap(yearMonth => {
+    const [year, month] = yearMonth.split('-').map(Number);
+    const monthPosts = sortedPosts.filter(post => {
+      const date = new Date(post.data.date);
+      return date.getFullYear() === year && date.getMonth() === month - 1;
+    });
+
+    const pageSize = 4;
+    const totalPages = Math.ceil(monthPosts.length / pageSize);
+
+    // Skip page 1 as it's handled by index.astro
+    return Array.from({ length: totalPages - 1 }, (_, i) => {
+      const pageNum = i + 2; // Start from page 2
+      const start = (pageNum - 1) * pageSize;
+      const end = start + pageSize;
+
+      return {
+        params: { 
+          year: String(year), 
+          month: String(month).padStart(2, '0'),
+          page: String(pageNum)
+        },
+        props: {
+          year,
+          month,
+          page: {
+            data: monthPosts.slice(start, end),
+            start,
+            end,
+            total: monthPosts.length,
+            currentPage: pageNum,
+            size: pageSize,
+            lastPage: totalPages,
+            url: {
+              current: `/archives/${year}/${month}/page/${pageNum}`,
+              prev: pageNum === 2 ? `/archives/${year}/${month}` : `/archives/${year}/${month}/page/${pageNum - 1}`,
+              next: pageNum < totalPages ? `/archives/${year}/${month}/page/${pageNum + 1}` : undefined,
+              first: `/archives/${year}/${month}`,
+              last: `/archives/${year}/${month}/page/${totalPages}`
+            }
+          }
+        }
+      };
+    });
+  });
+}
+
+const { page, year, month } = Astro.props;
+const monthName = new Date(year, month - 1).toLocaleString('en-US', { month: 'long' });
+const paddedMonth = String(month).padStart(2, '0');
+---
+
+<Layout title={`Archives for ${monthName} ${year} - Page ${page.currentPage}`}>
+    <h1 class="text-2xl pl-4 pt-8 font-bold mb-8 text-gray-800 dark:text-gray-200">
+      Archives for {monthName} {year}
+    </h1>
+
+    {page.data.map((post: Post) => <BlogPostPreview post={post} />)}
+
+    <Pagination 
+      page={page}
+      urlPattern={(pageNum) => `/archives/${year}/${paddedMonth}${pageNum === 1 ? '' : `/page/${pageNum}`}`}
+    />
+</Layout>

--- a/src/pages/archives/[year]/[month]/page/[page].astro
+++ b/src/pages/archives/[year]/[month]/page/[page].astro
@@ -4,8 +4,13 @@ import { getCollection } from 'astro:content';
 import BlogPostPreview from '../../../../../components/BlogPostPreview.astro';
 import Pagination from '../../../../../components/Pagination.astro';
 import type { CollectionEntry } from 'astro:content';
+import type { Page } from 'astro';
 
-type Post = CollectionEntry<'posts'>;
+type Props = {
+  year: number;
+  month: number;
+  page: Page<CollectionEntry<'posts'>>;
+};
 
 export async function getStaticPaths() {
   const allPosts = await getCollection("posts");
@@ -13,7 +18,6 @@ export async function getStaticPaths() {
     new Date(b.data.date).getTime() - new Date(a.data.date).getTime()
   );
 
-  // Get unique year/month combinations
   const yearMonths = [...new Set(sortedPosts.map(post => {
     const date = new Date(post.data.date);
     return `${date.getFullYear()}-${date.getMonth() + 1}`;
@@ -28,38 +32,40 @@ export async function getStaticPaths() {
 
     const pageSize = 4;
     const totalPages = Math.ceil(monthPosts.length / pageSize);
+    const paddedMonth = String(month).padStart(2, '0');
 
-    // Skip page 1 as it's handled by index.astro
     return Array.from({ length: totalPages - 1 }, (_, i) => {
-      const pageNum = i + 2; // Start from page 2
+      const pageNum = i + 2;
       const start = (pageNum - 1) * pageSize;
       const end = start + pageSize;
+
+      const paginated: Page<CollectionEntry<'posts'>> = {
+        data: monthPosts.slice(start, end),
+        start,
+        end,
+        total: monthPosts.length,
+        currentPage: pageNum,
+        size: pageSize,
+        lastPage: totalPages,
+        url: {
+          current: `/archives/${year}/${paddedMonth}/page/${pageNum}`,
+          prev: pageNum === 2 ? `/archives/${year}/${paddedMonth}` : `/archives/${year}/${paddedMonth}/page/${pageNum - 1}`,
+          next: pageNum < totalPages ? `/archives/${year}/${paddedMonth}/page/${pageNum + 1}` : undefined,
+          first: `/archives/${year}/${paddedMonth}`,
+          last: pageNum === totalPages ? undefined : `/archives/${year}/${paddedMonth}/page/${totalPages}`
+        }
+      };
 
       return {
         params: { 
           year: String(year), 
-          month: String(month).padStart(2, '0'),
+          month: paddedMonth,
           page: String(pageNum)
         },
         props: {
           year,
           month,
-          page: {
-            data: monthPosts.slice(start, end),
-            start,
-            end,
-            total: monthPosts.length,
-            currentPage: pageNum,
-            size: pageSize,
-            lastPage: totalPages,
-            url: {
-              current: `/archives/${year}/${month}/page/${pageNum}`,
-              prev: pageNum === 2 ? `/archives/${year}/${month}` : `/archives/${year}/${month}/page/${pageNum - 1}`,
-              next: pageNum < totalPages ? `/archives/${year}/${month}/page/${pageNum + 1}` : undefined,
-              first: `/archives/${year}/${month}`,
-              last: `/archives/${year}/${month}/page/${totalPages}`
-            }
-          }
+          page: paginated
         }
       };
     });
@@ -76,7 +82,7 @@ const paddedMonth = String(month).padStart(2, '0');
       Archives for {monthName} {year}
     </h1>
 
-    {page.data.map((post: Post) => <BlogPostPreview post={post} />)}
+    {page.data.map((post) => <BlogPostPreview post={post} />)}
 
     <Pagination 
       page={page}

--- a/src/pages/archives/[year]/index.astro
+++ b/src/pages/archives/[year]/index.astro
@@ -41,8 +41,8 @@ const page = {
     current: `/archives/${year}`,
     next: totalPosts > 4 ? `/archives/${year}/page/2` : undefined,
     prev: undefined,
-    first: `/archives/${year}`,
-    last: `/archives/${year}/page/${Math.ceil(totalPosts / 4)}`
+    first: undefined, // Remove first page link on first page
+    last: totalPosts > 4 ? `/archives/${year}/page/${Math.ceil(totalPosts / 4)}` : undefined
   }
 };
 ---

--- a/src/pages/archives/[year]/index.astro
+++ b/src/pages/archives/[year]/index.astro
@@ -3,12 +3,11 @@ import Layout from '../../../layouts/Layout.astro';
 import { getCollection } from 'astro:content';
 import BlogPostPreview from '../../../components/BlogPostPreview.astro';
 import Pagination from '../../../components/Pagination.astro';
-import type { Page } from 'astro';
 import type { CollectionEntry } from 'astro:content';
 
 type Post = CollectionEntry<'posts'>;
 
-export async function getStaticPaths({ paginate }: { paginate: Function }) {
+export async function getStaticPaths() {
   const allPosts = await getCollection("posts");
   const sortedPosts = allPosts.sort((a, b) => 
     new Date(b.data.date).getTime() - new Date(a.data.date).getTime()
@@ -18,19 +17,34 @@ export async function getStaticPaths({ paginate }: { paginate: Function }) {
     new Date(post.data.date).getFullYear()
   ))];
 
-  return years.flatMap(year => {
+  return years.map(year => {
     const yearPosts = sortedPosts.filter(post => 
       new Date(post.data.date).getFullYear() === year
     );
-    return paginate(yearPosts, {
+    return {
       params: { year: String(year) },
-      pageSize: 4,
-      props: { year }
-    });
+      props: { posts: yearPosts.slice(0, 4), year, totalPosts: yearPosts.length }
+    };
   });
 }
 
-const { page, year } = Astro.props;
+const { posts, year, totalPosts } = Astro.props;
+const page = {
+  data: posts,
+  start: 0,
+  end: 4,
+  total: totalPosts,
+  currentPage: 1,
+  size: 4,
+  lastPage: Math.ceil(totalPosts / 4),
+  url: {
+    current: `/archives/${year}`,
+    next: totalPosts > 4 ? `/archives/${year}/page/2` : undefined,
+    prev: undefined,
+    first: `/archives/${year}`,
+    last: `/archives/${year}/page/${Math.ceil(totalPosts / 4)}`
+  }
+};
 ---
 
 <Layout title={`Archives for ${year}`}>
@@ -38,10 +52,10 @@ const { page, year } = Astro.props;
       Archives for {year}
     </h1>
 
-    {page.data.map((post: Post) => <BlogPostPreview post={post} />)}
+    {posts.map((post: Post) => <BlogPostPreview post={post} />)}
 
     <Pagination 
-      page={page} 
-      urlPattern={(pageNum) => `/archives/${year}${pageNum === 1 ? '' : `/page/${pageNum}`}`} 
+      page={page}
+      urlPattern={(pageNum) => `/archives/${year}${pageNum === 1 ? '' : `/page/${pageNum}`}`}
     />
 </Layout>

--- a/src/pages/archives/[year]/page/[page].astro
+++ b/src/pages/archives/[year]/page/[page].astro
@@ -48,7 +48,7 @@ export async function getStaticPaths() {
               prev: pageNum === 2 ? `/archives/${year}` : `/archives/${year}/page/${pageNum - 1}`,
               next: pageNum < totalPages ? `/archives/${year}/page/${pageNum + 1}` : undefined,
               first: `/archives/${year}`,
-              last: `/archives/${year}/page/${totalPages}`
+              last: pageNum === totalPages ? undefined : `/archives/${year}/page/${totalPages}` // Remove last page link on last page
             }
           }
         }

--- a/src/pages/archives/[year]/page/[page].astro
+++ b/src/pages/archives/[year]/page/[page].astro
@@ -1,0 +1,74 @@
+---
+import Layout from '../../../../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+import BlogPostPreview from '../../../../components/BlogPostPreview.astro';
+import Pagination from '../../../../components/Pagination.astro';
+import type { CollectionEntry } from 'astro:content';
+
+type Post = CollectionEntry<'posts'>;
+
+export async function getStaticPaths() {
+  const allPosts = await getCollection("posts");
+  const sortedPosts = allPosts.sort((a, b) => 
+    new Date(b.data.date).getTime() - new Date(a.data.date).getTime()
+  );
+
+  const years = [...new Set(sortedPosts.map(post => 
+    new Date(post.data.date).getFullYear()
+  ))];
+
+  return years.flatMap(year => {
+    const yearPosts = sortedPosts.filter(post => 
+      new Date(post.data.date).getFullYear() === year
+    );
+    
+    const pageSize = 4;
+    const totalPages = Math.ceil(yearPosts.length / pageSize);
+    
+    // Skip page 1 as it's handled by index.astro
+    return Array.from({ length: totalPages - 1 }, (_, i) => {
+      const pageNum = i + 2; // Start from page 2
+      const start = (pageNum - 1) * pageSize;
+      const end = start + pageSize;
+      
+      return {
+        params: { year: String(year), page: String(pageNum) },
+        props: {
+          year,
+          page: {
+            data: yearPosts.slice(start, end),
+            start,
+            end,
+            total: yearPosts.length,
+            currentPage: pageNum,
+            size: pageSize,
+            lastPage: totalPages,
+            url: {
+              current: `/archives/${year}/page/${pageNum}`,
+              prev: pageNum === 2 ? `/archives/${year}` : `/archives/${year}/page/${pageNum - 1}`,
+              next: pageNum < totalPages ? `/archives/${year}/page/${pageNum + 1}` : undefined,
+              first: `/archives/${year}`,
+              last: `/archives/${year}/page/${totalPages}`
+            }
+          }
+        }
+      };
+    });
+  });
+}
+
+const { page, year } = Astro.props;
+---
+
+<Layout title={`Archives for ${year} - Page ${page.currentPage}`}>
+    <h1 class="text-2xl pl-4 pt-8 font-bold mb-8 text-gray-800 dark:text-gray-200">
+      Archives for {year}
+    </h1>
+
+    {page.data.map((post: Post) => <BlogPostPreview post={post} />)}
+
+    <Pagination 
+      page={page} 
+      urlPattern={(pageNum) => `/archives/${year}${pageNum === 1 ? '' : `/page/${pageNum}`}`} 
+    />
+</Layout>


### PR DESCRIPTION
Introduce paginated archive pages for each year and month, enhancing navigation through blog posts. Refactor pagination logic for improved clarity and maintainability.